### PR TITLE
Only have posts tagged 'front' on the front page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,9 +18,9 @@ description: Resisting the Trump Agenda in Central Texas
 
 # List of links in the navigation bar
 navbar-links:
+  About: "about"
+  News: "posts"
   More:
-    - About: "about"
-    - Blog: "posts"
     - Get Involved: "get-involved"
     - Make Contact: "make-contact"
     - FAQ: "faq"

--- a/_config.yml
+++ b/_config.yml
@@ -18,10 +18,12 @@ description: Resisting the Trump Agenda in Central Texas
 
 # List of links in the navigation bar
 navbar-links:
-  About: "about"
-  Get Involved: "get-involved"
-  Make Contact: "make-contact"
-  FAQ: "faq"
+  More:
+    - About: "about"
+    - Blog: "posts"
+    - Get Involved: "get-involved"
+    - Make Contact: "make-contact"
+    - FAQ: "faq"
   Indivisible Sites:
     - Indivisible Guide: "https://www.indivisibleguide.com/"
     - Indivisible Austin: "http://www.indivisibleaustin.com/"

--- a/index.html
+++ b/index.html
@@ -24,59 +24,61 @@ the power to resist — and we have the power to win.</p>
 <div class="page-heading">
 <div class="page-subheading">
 <hr class="small" />
-<p class="page-subheading">News and Announcements</p>
+<p class="page-subheading">Calls to Action<p>
 </div>
 </div>
 </div>
 
 <div class="posts-list">
   {% for post in paginator.posts %}
-  <article class="post-preview">
-    <a href="{{ post.url | prepend: site.baseurl }}">
-	  <h2 class="post-title">{{ post.title }}</h2>
+    {% if post.tags contains 'action-alert' %}
+    <article class="post-preview">
+      <a href="{{ post.url | prepend: site.baseurl }}">
+  	  <h2 class="post-title">{{ post.title }}</h2>
 
-	  {% if post.subtitle %}
-	  <h3 class="post-subtitle">
-	    {{ post.subtitle }}
-	  </h3>
-	  {% endif %}
-    </a>
+  	  {% if post.subtitle %}
+  	  <h3 class="post-subtitle">
+  	    {{ post.subtitle }}
+  	  </h3>
+  	  {% endif %}
+      </a>
 
-    <p class="post-meta">
-      Posted on {{ post.date | date: "%B %-d, %Y" }}
-    </p>
+      <p class="post-meta">
+        Posted on {{ post.date | date: "%B %-d, %Y" }}
+      </p>
 
-    <div class="post-entry-container">
-      {% if post.image %}
-      <div class="post-image">
-        <a href="{{ post.url | prepend: site.baseurl }}">
-          <img src="{{ post.image }}">
-        </a>
+      <div class="post-entry-container">
+        {% if post.image %}
+        <div class="post-image">
+          <a href="{{ post.url | prepend: site.baseurl }}">
+            <img src="{{ post.image }}">
+          </a>
+        </div>
+        {% endif %}
+        <div class="post-entry">
+          {{ post.excerpt | strip_html | xml_escape | truncatewords: site.excerpt_length }}
+          {% assign excerpt_word_count = post.excerpt | number_of_words %}
+          {% if post.content != post.excerpt or excerpt_word_count > site.excerpt_length %}
+            <a href="{{ post.url | prepend: site.baseurl }}" class="post-read-more">[Read&nbsp;More]</a>
+          {% endif %}
+        </div>
       </div>
-      {% endif %}
-      <div class="post-entry">
-        {{ post.excerpt | strip_html | xml_escape | truncatewords: site.excerpt_length }}
-        {% assign excerpt_word_count = post.excerpt | number_of_words %}
-        {% if post.content != post.excerpt or excerpt_word_count > site.excerpt_length %}
-          <a href="{{ post.url | prepend: site.baseurl }}" class="post-read-more">[Read&nbsp;More]</a>
+
+      {% if post.tags.size > 0 %}
+      <div class="blog-tags">
+        Tags:
+        {% if site.link-tags %}
+        {% for tag in post.tags %}
+        <a href="{{ site.baseurl }}/tag/{{ tag }}">{{ tag }}</a>
+        {% endfor %}
+        {% else %}
+          {{ post.tags | join: ", " }}
         {% endif %}
       </div>
-    </div>
-
-    {% if post.tags.size > 0 %}
-    <div class="blog-tags">
-      Tags:
-      {% if site.link-tags %}
-      {% for tag in post.tags %}
-      <a href="{{ site.baseurl }}/tag/{{ tag }}">{{ tag }}</a>
-      {% endfor %}
-      {% else %}
-        {{ post.tags | join: ", " }}
       {% endif %}
-    </div>
-    {% endif %}
 
-   </article>
+     </article>
+    {% endif %}
   {% endfor %}
 </div>
 
@@ -84,13 +86,20 @@ the power to resist — and we have the power to win.</p>
 <ul class="pager main-pager">
   {% if paginator.previous_page %}
   <li class="previous">
-    <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">&larr; Newer Posts</a>
+    <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">&larr; Newer Calls</a>
   </li>
   {% endif %}
   {% if paginator.next_page %}
   <li class="next">
-    <a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}">Older Posts &rarr;</a>
+    <a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}">Older Calls &rarr;</a>
   </li>
   {% endif %}
 </ul>
 {% endif %}
+
+
+<div style="text-align: center;">
+  <ul class="pager main-pager">
+    <li><a href="/posts">All blog posts</a></li>
+  </ul>
+</div>

--- a/index.html
+++ b/index.html
@@ -20,18 +20,9 @@ the power to resist — and we have the power to win.</p>
 
 </div>
 
-<div class="intro-header" style="margin-top: 4em">
-<div class="page-heading">
-<div class="page-subheading">
-<hr class="small" />
-<p class="page-subheading">Calls to Action<p>
-</div>
-</div>
-</div>
-
 <div class="posts-list">
-  {% for post in paginator.posts %}
-    {% if post.tags contains 'action-alert' %}
+  {% for post in site.posts %}
+    {% if post.tags contains 'front' %}
     <article class="post-preview">
       <a href="{{ post.url | prepend: site.baseurl }}">
   	  <h2 class="post-title">{{ post.title }}</h2>
@@ -82,24 +73,9 @@ the power to resist — and we have the power to win.</p>
   {% endfor %}
 </div>
 
-{% if paginator.total_pages > 1 %}
-<ul class="pager main-pager">
-  {% if paginator.previous_page %}
-  <li class="previous">
-    <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">&larr; Newer Calls</a>
-  </li>
-  {% endif %}
-  {% if paginator.next_page %}
-  <li class="next">
-    <a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}">Older Calls &rarr;</a>
-  </li>
-  {% endif %}
-</ul>
-{% endif %}
-
 
 <div style="text-align: center;">
   <ul class="pager main-pager">
-    <li><a href="/posts">All blog posts</a></li>
+    <li><a href="/posts">All News</a></li>
   </ul>
 </div>

--- a/posts.html
+++ b/posts.html
@@ -1,0 +1,79 @@
+---
+layout: page
+title: Blog
+---
+
+<div class="intro-header" style="margin-top: 4em">
+<div class="page-heading">
+<div class="page-subheading">
+<hr class="small" />
+<p class="page-subheading">All posts<p>
+</div>
+</div>
+</div>
+
+<div class="posts-list">
+  {% for post in site.posts %}
+  <article class="post-preview">
+    <a href="{{ post.url | prepend: site.baseurl }}">
+	  <h2 class="post-title">{{ post.title }}</h2>
+
+	  {% if post.subtitle %}
+	  <h3 class="post-subtitle">
+	    {{ post.subtitle }}
+	  </h3>
+	  {% endif %}
+    </a>
+
+    <p class="post-meta">
+      Posted on {{ post.date | date: "%B %-d, %Y" }}
+    </p>
+
+    <div class="post-entry-container">
+      {% if post.image %}
+      <div class="post-image">
+        <a href="{{ post.url | prepend: site.baseurl }}">
+          <img src="{{ post.image }}">
+        </a>
+      </div>
+      {% endif %}
+      <div class="post-entry">
+        {{ post.excerpt | strip_html | xml_escape | truncatewords: site.excerpt_length }}
+        {% assign excerpt_word_count = post.excerpt | number_of_words %}
+        {% if post.content != post.excerpt or excerpt_word_count > site.excerpt_length %}
+          <a href="{{ post.url | prepend: site.baseurl }}" class="post-read-more">[Read&nbsp;More]</a>
+        {% endif %}
+      </div>
+    </div>
+
+    {% if post.tags.size > 0 %}
+    <div class="blog-tags">
+      Tags:
+      {% if site.link-tags %}
+      {% for tag in post.tags %}
+      <a href="{{ site.baseurl }}/tag/{{ tag }}">{{ tag }}</a>
+      {% endfor %}
+      {% else %}
+        {{ post.tags | join: ", " }}
+      {% endif %}
+    </div>
+    {% endif %}
+
+   </article>
+  {% endfor %}
+</div>
+
+{% if paginator.total_pages > 1 %}
+<ul class="pager main-pager">
+  {% if paginator.previous_page %}
+  <li class="previous">
+    <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">&larr; Newer Posts</a>
+  </li>
+  {% endif %}
+  {% if paginator.next_page %}
+  <li class="next">
+    <a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}">Older Posts &rarr;</a>
+  </li>
+  {% endif %}
+</ul>
+{% endif %}

--- a/posts.html
+++ b/posts.html
@@ -1,16 +1,7 @@
 ---
 layout: page
-title: Blog
+title: News
 ---
-
-<div class="intro-header" style="margin-top: 4em">
-<div class="page-heading">
-<div class="page-subheading">
-<hr class="small" />
-<p class="page-subheading">All posts<p>
-</div>
-</div>
-</div>
 
 <div class="posts-list">
   {% for post in site.posts %}
@@ -62,18 +53,3 @@ title: Blog
    </article>
   {% endfor %}
 </div>
-
-{% if paginator.total_pages > 1 %}
-<ul class="pager main-pager">
-  {% if paginator.previous_page %}
-  <li class="previous">
-    <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">&larr; Newer Posts</a>
-  </li>
-  {% endif %}
-  {% if paginator.next_page %}
-  <li class="next">
-    <a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}">Older Posts &rarr;</a>
-  </li>
-  {% endif %}
-</ul>
-{% endif %}


### PR DESCRIPTION
And a bunch of other little changes -- all are open to suggestion.

- The front page posts are now filtered to just those tagged 'action-alert'
- There's a new page titled "Blog" at the path "/posts" with *all* posts
- Links to the blog page

Here's a new link to "All Posts" at the bottom of the front page:

![image](https://cloud.githubusercontent.com/assets/575305/22006080/e7fb2f64-dc2d-11e6-97dc-c8666a34852f.png)

- The navbar links were already crowded on my Chrome, so I put them under a new menu lamely titled "More".

Here's what the nav links look like (the pink circle doesn't really appear on the site):

![image](https://cloud.githubusercontent.com/assets/575305/22006026/7703a7e6-dc2d-11e6-9793-7f1638e53272.png)

![image](https://cloud.githubusercontent.com/assets/575305/22006048/9811517c-dc2d-11e6-9b18-dacf1d2c4362.png)


